### PR TITLE
Update JNA version to support Apple M1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val root = (project in file(".")).settings(
   crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.5"),
   libraryDependencies ++= Seq(
     "com.github.pathikrit" %% "better-files" % "3.8.0",
-    "net.java.dev.jna" % "jna" % "5.4.0",
+    "net.java.dev.jna" % "jna" % "5.12.1",
     "org.scalatest" %% "scalatest" % "3.0.8" % Test
   ),
   fork := true,


### PR DESCRIPTION
Fixing the [issue#17](https://github.com/annoy4s/annoy4s/issues/17) where current implementation fails `sbt test` on Apple M1 cpu.

After updating `"net.java.dev.jna" % "jna"` to the latest `"5.12.1"` `sbt test` succeeds and dependent project [issue#4515](https://github.com/spotify/scio/issues/4515) also is fixed using locally built jar.
